### PR TITLE
CreateTable первичный ключ из нескольких полей

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -450,12 +450,12 @@ class Session
     /**
      * @param string $table
      * @param mixed $columns
-     * @param string $primary_key
+     * @param array $primary_key
      * @param array $indexes
      * @return bool|mixed|void|null
      * @throws Exception
      */
-    public function createTable($table, $columns, $primary_key = 'id', $indexes = [])
+    public function createTable($table, $columns, $primary_key = ['id'], $indexes = [])
     {
         $data = [
             'path' => $this->pathPrefix($table),


### PR DESCRIPTION
Первичный ключ может состоять из нескольких полей, если строкой передать "field1,field2", то это приводит к ошибке, необходимо передавать именно массив полей