### PR TITLE
Lock lcobucci/jwt version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-json": "*",
         "google/protobuf": "~3.15.8",
         "grpc/grpc": "^1.35",
-        "lcobucci/jwt": "^4.1.5",
+        "lcobucci/jwt": "4.1.5",
         "phpseclib/phpseclib": "^2.0|^3.0",
         "psr/log": "~1.0"
     },


### PR DESCRIPTION
In the current implementation, sdk only supports version 4.1.5, using any new version results in an error