### PR TITLE
Added $opts array for customize gRPC client options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* added `$opts` array for customize gRPC client options
+
 ## 1.14.0
 * added `ScanQueryMode` for `Table::scanQuery`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* added `$opts` array for customize gRPC client options
+* added `$grpc_config` array for customize gRPC behavior
 
 ## 1.14.0
 * added `ScanQueryMode` for `Table::scanQuery`

--- a/README.md
+++ b/README.md
@@ -562,19 +562,22 @@ $config = [
 $ydb = new \YdbPlatform\Ydb\Ydb($config);
 ```
 
-## gRPC options
+## gRPC
 
+### gRPC client's options
 You can customize the gRPC client's behavior by setting options in config array
 
 Example of using:
 ```php
 $config = [
     // ...
-    'opts' => [
-        'grpc.max_receive_message_length' => 8*1024*1024,
-        'grpc.default_compression_algorithm' => 2,
-        'grpc.default_compression_level' => 2,
+    'grpc' => [
+        'opts' => [
+            'grpc.max_receive_message_length' => 8*1024*1024,
+            'grpc.default_compression_algorithm' => 2,
+            'grpc.default_compression_level' => 2,
+        ],
     ],
-]
+];
 $ydb = new \YdbPlatform\Ydb\Ydb($config);
 ```

--- a/README.md
+++ b/README.md
@@ -562,3 +562,19 @@ $config = [
 $ydb = new \YdbPlatform\Ydb\Ydb($config);
 ```
 
+## gRPC options
+
+You can customize the gRPC client's behavior by setting options in config array
+
+Example of using:
+```php
+$config = [
+    // ...
+    'opts' => [
+        'grpc.max_receive_message_length' => 8*1024*1024,
+        'grpc.default_compression_algorithm' => 2,
+        'grpc.default_compression_level' => 2,
+    ],
+]
+$ydb = new \YdbPlatform\Ydb\Ydb($config);
+```

--- a/src/AuthService.php
+++ b/src/AuthService.php
@@ -28,7 +28,7 @@ class AuthService{
     {
         $this->ydb = $ydb;
         $this->logger = $logger;
-        $this->client = new ServiceClient($ydb->endpoint(), $ydb->opts());
+        $this->client = new ServiceClient($ydb->endpoint(), $ydb->grpcOpts());
         $this->credentials = $ydb->iam();
         $this->meta = [
             'x-ydb-database' => [$ydb->database()],

--- a/src/AuthService.php
+++ b/src/AuthService.php
@@ -28,9 +28,7 @@ class AuthService{
     {
         $this->ydb = $ydb;
         $this->logger = $logger;
-        $this->client = new ServiceClient($ydb->endpoint(), [
-            'credentials' => $ydb->iam()->getCredentials(),
-        ]);
+        $this->client = new ServiceClient($ydb->endpoint(), $ydb->opts());
         $this->credentials = $ydb->iam();
         $this->meta = [
             'x-ydb-database' => [$ydb->database()],

--- a/src/Discovery.php
+++ b/src/Discovery.php
@@ -43,7 +43,7 @@ class Discovery
     {
         $this->ydb = $ydb;
 
-        $this->client = new ServiceClient($ydb->endpoint(), $ydb->opts());
+        $this->client = new ServiceClient($ydb->endpoint(), $ydb->grpcOpts());
 
         $this->meta = $ydb->meta();
 

--- a/src/Discovery.php
+++ b/src/Discovery.php
@@ -43,9 +43,7 @@ class Discovery
     {
         $this->ydb = $ydb;
 
-        $this->client = new ServiceClient($ydb->endpoint(), [
-            'credentials' => $ydb->iam()->getCredentials(),
-        ]);
+        $this->client = new ServiceClient($ydb->endpoint(), $ydb->opts());
 
         $this->meta = $ydb->meta();
 

--- a/src/Operations.php
+++ b/src/Operations.php
@@ -38,9 +38,7 @@ class Operations
     {
         $this->ydb = $ydb;
 
-        $this->client = new ServiceClient($ydb->endpoint(), [
-            'credentials' => $ydb->iam()->getCredentials(),
-        ]);
+        $this->client = new ServiceClient($ydb->endpoint(), $ydb->opts());
 
         $this->meta = $ydb->meta();
 

--- a/src/Operations.php
+++ b/src/Operations.php
@@ -38,7 +38,7 @@ class Operations
     {
         $this->ydb = $ydb;
 
-        $this->client = new ServiceClient($ydb->endpoint(), $ydb->opts());
+        $this->client = new ServiceClient($ydb->endpoint(), $ydb->grpcOpts());
 
         $this->meta = $ydb->meta();
 

--- a/src/Scheme.php
+++ b/src/Scheme.php
@@ -41,9 +41,7 @@ class Scheme
     {
         $this->ydb = $ydb;
 
-        $this->client = new ServiceClient($ydb->endpoint(), [
-            'credentials' => $ydb->iam()->getCredentials(),
-        ]);
+        $this->client = new ServiceClient($ydb->endpoint(), $ydb->opts());
 
         $this->meta = $ydb->meta();
 

--- a/src/Scheme.php
+++ b/src/Scheme.php
@@ -41,7 +41,7 @@ class Scheme
     {
         $this->ydb = $ydb;
 
-        $this->client = new ServiceClient($ydb->endpoint(), $ydb->opts());
+        $this->client = new ServiceClient($ydb->endpoint(), $ydb->grpcOpts());
 
         $this->meta = $ydb->meta();
 

--- a/src/Scripting.php
+++ b/src/Scripting.php
@@ -38,9 +38,7 @@ class Scripting
     {
         $this->ydb = $ydb;
 
-        $this->client = new ServiceClient($ydb->endpoint(), [
-            'credentials' => $ydb->iam()->getCredentials(),
-        ]);
+        $this->client = new ServiceClient($ydb->endpoint(), $ydb->opts());
 
         $this->meta = $ydb->meta();
 

--- a/src/Scripting.php
+++ b/src/Scripting.php
@@ -38,7 +38,7 @@ class Scripting
     {
         $this->ydb = $ydb;
 
-        $this->client = new ServiceClient($ydb->endpoint(), $ydb->opts());
+        $this->client = new ServiceClient($ydb->endpoint(), $ydb->grpcOpts());
 
         $this->meta = $ydb->meta();
 

--- a/src/Table.php
+++ b/src/Table.php
@@ -75,9 +75,7 @@ class Table
     {
         $this->ydb = $ydb;
 
-        $this->client = new ServiceClient($ydb->endpoint(), [
-            'credentials' => $ydb->iam()->getCredentials(),
-        ]);
+        $this->client = new ServiceClient($ydb->endpoint(), $ydb->opts());
 
         $this->meta = $ydb->meta();
 

--- a/src/Table.php
+++ b/src/Table.php
@@ -75,7 +75,7 @@ class Table
     {
         $this->ydb = $ydb;
 
-        $this->client = new ServiceClient($ydb->endpoint(), $ydb->opts());
+        $this->client = new ServiceClient($ydb->endpoint(), $ydb->grpcOpts());
 
         $this->meta = $ydb->meta();
 

--- a/src/Traits/RequestTrait.php
+++ b/src/Traits/RequestTrait.php
@@ -193,7 +193,7 @@ trait RequestTrait
             if ($this->ydb->needDiscovery() && count($this->ydb->cluster()->all()) > 0){
                 $endpoint = $this->ydb->cluster()->all()[array_rand($this->ydb->cluster()->all())]->endpoint();
             }
-            $this->client = new $this->client($endpoint, $this->ydb->opts());
+            $this->client = new $this->client($endpoint, $this->ydb->grpcOpts());
             if (isset(self::$grpcExceptions[$status->code])) {
                 throw new self::$grpcExceptions[$status->code]($message);
             } else {

--- a/src/Traits/RequestTrait.php
+++ b/src/Traits/RequestTrait.php
@@ -193,9 +193,7 @@ trait RequestTrait
             if ($this->ydb->needDiscovery() && count($this->ydb->cluster()->all()) > 0){
                 $endpoint = $this->ydb->cluster()->all()[array_rand($this->ydb->cluster()->all())]->endpoint();
             }
-            $this->client = new $this->client($endpoint,[
-                'credentials' => $this->ydb->iam()->getCredentials()
-            ]);
+            $this->client = new $this->client($endpoint, $this->ydb->opts());
             if (isset(self::$grpcExceptions[$status->code])) {
                 throw new self::$grpcExceptions[$status->code]($message);
             } else {

--- a/src/Ydb.php
+++ b/src/Ydb.php
@@ -40,7 +40,7 @@ class Ydb
     /**
      * @var array
      */
-    protected $opts;
+    protected $grpc_config;
 
     /**
      * @var Iam
@@ -111,7 +111,7 @@ class Ydb
         $this->endpoint = $config['endpoint'] ?? null;
         $this->database = $config['database'] ?? null;
         $this->iam_config = $config['iam_config'] ?? [];
-        $this->opts = $config['opts'] ?? [];
+        $this->grpc_config = (array) ($config['grpc'] ?? []);
 
         if (!is_null($logger) && isset($config['logger'])){
             throw new \Exception('Logger set in 2 places');
@@ -179,12 +179,12 @@ class Ydb
         return $meta;
     }
 
-    public function opts(): array
+    public function grpcOpts(): array
     {
-        $opts = $this->opts;
-        $opts['credentials'] = $this->iam()->getCredentials();
+        $grpcOpts = (array) ($this->grpc_config['opts'] ?? []);
+        $grpcOpts['credentials'] = $this->iam()->getCredentials();
 
-        return $opts;
+        return $grpcOpts;
     }
 
     /**

--- a/src/Ydb.php
+++ b/src/Ydb.php
@@ -38,6 +38,11 @@ class Ydb
     protected $iam_config;
 
     /**
+     * @var array
+     */
+    protected $opts;
+
+    /**
      * @var Iam
      */
     protected $iam;
@@ -106,6 +111,7 @@ class Ydb
         $this->endpoint = $config['endpoint'] ?? null;
         $this->database = $config['database'] ?? null;
         $this->iam_config = $config['iam_config'] ?? [];
+        $this->opts = $config['opts'] ?? [];
 
         if (!is_null($logger) && isset($config['logger'])){
             throw new \Exception('Logger set in 2 places');
@@ -171,6 +177,14 @@ class Ydb
         }
 
         return $meta;
+    }
+
+    public function opts(): array
+    {
+        $opts = $this->opts;
+        $opts['credentials'] = $this->iam()->getCredentials();
+
+        return $opts;
     }
 
     /**


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

## Pull request type

Please check the type of change your PR introduces:

- [x] Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [#136](https://github.com/ydb-platform/ydb-php-sdk/issues/136)

## What is the new behavior?

You can customize the gRPC client's behavior by setting options in config array

Example of using:
```php
$config = [
    // ...
    'opts' => [
        'grpc.max_receive_message_length' => 8*1024*1024,
        'grpc.default_compression_algorithm' => 2,
        'grpc.default_compression_level' => 2,
    ],
]
$ydb = new \YdbPlatform\Ydb\Ydb($config);