### PR TITLE
Fixed discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+* added resilient internal endpoint discovery (`YdbPlatform\Ydb\Internal\Discovery`) that always targets the original bootstrap endpoint and recreates the gRPC channel with `force_new` on retries to bust the c-core DNS cache and survive bootstrap IP changes
+* added discovery tuning config keys: `discoveryTimeoutMs` (default 5000), `discoveryAttemptTimeoutMs` (default 1000), `discoveryInitialTimeoutMs` (default 5000; set to `PHP_INT_MAX` to wait indefinitely on startup)
+* set `grpc.lb_policy_name = round_robin` as the default for every gRPC channel built via `Ydb::grpcOpts()`; user overrides via `grpc.opts.grpc.lb_policy_name` are respected
+* fixed `array_search` cluster-endpoint check in `Ydb::discover()` (returned key 0 was treated as "not found"); replaced with strict `in_array`
+
 ## 1.16.0
 * added support operation timeout option
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 * added resilient internal endpoint discovery (`YdbPlatform\Ydb\Internal\Discovery`) that always targets the original bootstrap endpoint and recreates the gRPC channel with `force_new` on retries to bust the c-core DNS cache and survive bootstrap IP changes
-* added discovery tuning config keys: `discoveryTimeoutMs` (default 5000), `discoveryAttemptTimeoutMs` (default 1000), `discoveryInitialTimeoutMs` (default 5000; set to `PHP_INT_MAX` to wait indefinitely on startup)
+* added discovery tuning config keys: `discoveryTimeoutMs` (default 1000), `discoveryAttemptTimeoutMs` (default 300), `discoveryInitialTimeoutMs` (default 5000; set to `PHP_INT_MAX` to wait indefinitely on startup)
 * set `grpc.lb_policy_name = round_robin` as the default for every gRPC channel built via `Ydb::grpcOpts()`; user overrides via `grpc.opts.grpc.lb_policy_name` are respected
 * fixed `array_search` cluster-endpoint check in `Ydb::discover()` (returned key 0 was treated as "not found"); replaced with strict `in_array`
 

--- a/README.md
+++ b/README.md
@@ -562,6 +562,24 @@ $config = [
 $ydb = new \YdbPlatform\Ydb\Ydb($config);
 ```
 
+## Internal discovery
+
+Tuning keys for the internal endpoint discovery loop (used when `discovery => true`):
+
+- `discoveryTimeoutMs` (default `5000`) — total budget for one background discovery iteration (ms).
+- `discoveryAttemptTimeoutMs` (default `1000`) — per-attempt gRPC deadline for internal discovery (ms).
+- `discoveryInitialTimeoutMs` (default `5000`) — total budget for the startup discovery in the `Ydb` constructor (ms). If the cluster is unreachable longer than this, the constructor throws. To wait indefinitely for the cluster on startup, set this to `PHP_INT_MAX`:
+
+```php
+$config = [
+    // ...
+    'discovery' => true,
+    'discoveryInitialTimeoutMs' => PHP_INT_MAX,
+];
+```
+
+For cross-region or otherwise high-latency setups, bump `discoveryAttemptTimeoutMs` to 2000-3000 and `discoveryTimeoutMs` to 10000-15000 to give cold gRPC connects enough time to complete on retries.
+
 ## gRPC
 
 ### gRPC client's options

--- a/README.md
+++ b/README.md
@@ -562,23 +562,71 @@ $config = [
 $ydb = new \YdbPlatform\Ydb\Ydb($config);
 ```
 
-## Internal discovery
+## Discovery
 
-Tuning keys for the internal endpoint discovery loop (used when `discovery => true`):
+Endpoint discovery asks the cluster which nodes are currently
+serving the database, and balances subsequent requests across them.
+The SDK keeps the list fresh in the background and re-discovers
+automatically when a node becomes unavailable.
 
-- `discoveryTimeoutMs` (default `5000`) — total budget for one background discovery iteration (ms).
-- `discoveryAttemptTimeoutMs` (default `1000`) — per-attempt gRPC deadline for internal discovery (ms).
-- `discoveryInitialTimeoutMs` (default `5000`) — total budget for the startup discovery in the `Ydb` constructor (ms). If the cluster is unreachable longer than this, the constructor throws. To wait indefinitely for the cluster on startup, set this to `PHP_INT_MAX`:
 
-```php
-$config = [
-    // ...
-    'discovery' => true,
-    'discoveryInitialTimeoutMs' => PHP_INT_MAX,
-];
-```
+### Turning it on or off
 
-For cross-region or otherwise high-latency setups, bump `discoveryAttemptTimeoutMs` to 2000-3000 and `discoveryTimeoutMs` to 10000-15000 to give cold gRPC connects enough time to complete on retries.
+Controlled by the `discovery` config key. The default is `false` (off).
+
+    $config = [
+        // ...
+        'discovery' => true,
+    ];
+
+Turn it on for long-running processes that issue many queries per run —
+workers, daemons, web apps under heavy query load. You get load
+balancing across cluster nodes and automatic recovery when a node
+goes down, at the cost of one extra round-trip on startup plus a
+periodic background refresh.
+
+Leave it off for short-lived scripts that make only a handful of
+queries — cron jobs, CLI utilities, or simple PHP pages that finish 
+in under a minute and issue at most a couple of dozen queries to YDB. 
+The startup cost is not worth it: a single endpoint is enough, and 
+the script exits long before the background refresh would have mattered.
+
+
+### Tuning keys
+
+These apply only when `discovery => true`.
+
+    discoveryInterval            default 60       seconds
+    discoveryInitialTimeoutMs    default 5000     milliseconds
+    discoveryTimeoutMs           default 5000     milliseconds
+    discoveryAttemptTimeoutMs    default 1000     milliseconds
+
+- `discoveryInterval` — how often the background loop re-fetches
+  the endpoint list.
+
+- `discoveryInitialTimeoutMs` — total budget for the startup
+  discovery call in the `Ydb` constructor. If the cluster is
+  unreachable for longer than this, the constructor throws.
+  Set to `PHP_INT_MAX` to wait indefinitely on startup.
+
+- `discoveryTimeoutMs` — total budget for one background
+  re-discovery iteration.
+
+- `discoveryAttemptTimeoutMs` — per-attempt gRPC deadline inside
+  the discovery retry loop.
+
+Example — wait forever for the cluster on startup:
+
+    $config = [
+        // ...
+        'discovery' => true,
+        'discoveryInitialTimeoutMs' => PHP_INT_MAX,
+    ];
+
+For cross-region or otherwise high-latency setups, bump
+`discoveryAttemptTimeoutMs` to 200-300 and `discoveryTimeoutMs`
+to 1000-2000 so that cold gRPC connects have enough time to
+complete on retries.
 
 ## gRPC
 

--- a/README.md
+++ b/README.md
@@ -598,8 +598,8 @@ These apply only when `discovery => true`.
 
     discoveryInterval            default 60       seconds
     discoveryInitialTimeoutMs    default 5000     milliseconds
-    discoveryTimeoutMs           default 5000     milliseconds
-    discoveryAttemptTimeoutMs    default 1000     milliseconds
+    discoveryTimeoutMs           default 1000     milliseconds
+    discoveryAttemptTimeoutMs    default 300      milliseconds
 
 - `discoveryInterval` — how often the background loop re-fetches
   the endpoint list.
@@ -623,10 +623,10 @@ Example — wait forever for the cluster on startup:
         'discoveryInitialTimeoutMs' => PHP_INT_MAX,
     ];
 
-For cross-region or otherwise high-latency setups, bump
-`discoveryAttemptTimeoutMs` to 200-300 and `discoveryTimeoutMs`
-to 1000-2000 so that cold gRPC connects have enough time to
-complete on retries.
+For cross-region or otherwise high-latency setups, raise
+`discoveryInitialTimeoutMs` up to 15000 and triple the other two
+(`discoveryTimeoutMs` ≈ 3000, `discoveryAttemptTimeoutMs` ≈ 900)
+so that cold gRPC connects have enough time to complete on retries.
 
 ## gRPC
 

--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,12 @@
             "App\\": "examples/",
             "YdbPlatform\\Ydb\\Slo\\": "slo-workload"
         }
+    },
+    "config": {
+        "policy": {
+            "advisories": {
+                "ignore-id": ["PKSA-tcfz-w4fm-hhk9"]
+            }
+        }
     }
 }

--- a/src/Internal/Discovery.php
+++ b/src/Internal/Discovery.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace YdbPlatform\Ydb\Internal;
+
+use Psr\Log\LoggerInterface;
+use Ydb\Discovery\ListEndpointsRequest;
+use Ydb\Discovery\V1\DiscoveryServiceClient as ServiceClient;
+use YdbPlatform\Ydb\Exceptions\RetryableException;
+use YdbPlatform\Ydb\Traits\LoggerTrait;
+use YdbPlatform\Ydb\Traits\ParseResultTrait;
+use YdbPlatform\Ydb\Traits\RequestTrait;
+use YdbPlatform\Ydb\Ydb;
+
+/**
+ * @internal
+ */
+class Discovery
+{
+    use RequestTrait;
+    use ParseResultTrait;
+    use LoggerTrait;
+
+    const DEFAULT_TIMEOUT_MS         = 5000;
+    const DEFAULT_ATTEMPT_TIMEOUT_MS = 1000;
+    const DEFAULT_INITIAL_TIMEOUT_MS = 5000;
+
+    const BACKOFF_SLOT_MS = 20;
+    const BACKOFF_CEILING = 5;
+
+    /**
+     * @var ServiceClient|null Null until the first listEndpoints() call.
+     */
+    protected $client;
+
+    /**
+     * @var LoggerInterface|null
+     */
+    protected $logger;
+
+    /**
+     * @var string|null
+     */
+    protected $bootstrapEndpoint;
+
+    /**
+     * @var int
+     */
+    protected $timeoutMs;
+
+    /**
+     * @var int
+     */
+    protected $attemptTimeoutMs;
+
+    /**
+     * @var int
+     */
+    protected $initialTimeoutMs;
+
+    /**
+     * @var callable|null Null in production — the built-in ServiceClient ctor is used
+     *                    inline (see makeClient). Tests may inject a callable; that
+     *                    callable may be a Closure but only the test object holds it,
+     *                    and tests aren't serialized. Keeping null in production avoids
+     *                    putting a Closure into the iam_config graph of the inner Ydb
+     *                    used by StaticAuthentication, which Iam::parseConfig serializes
+     *                    for token-cache filename hashing.
+     */
+    protected $clientFactory;
+
+    /**
+     * Ctor only stores configuration. It does NOT touch credentials, build a gRPC stub,
+     * or fetch a token — all of that happens on the first listEndpoints() call. This
+     * lets Ydb construct the object unconditionally without side effects when discovery
+     * isn't enabled.
+     */
+    public function __construct(
+        Ydb $ydb,
+        ?string $bootstrapEndpoint,
+        int $timeoutMs = self::DEFAULT_TIMEOUT_MS,
+        int $attemptTimeoutMs = self::DEFAULT_ATTEMPT_TIMEOUT_MS,
+        int $initialTimeoutMs = self::DEFAULT_INITIAL_TIMEOUT_MS,
+        LoggerInterface $logger = null,
+        callable $clientFactory = null
+    ) {
+        $this->ydb = $ydb;
+        $this->logger = $logger;
+        $this->bootstrapEndpoint = $bootstrapEndpoint;
+        $this->timeoutMs = $timeoutMs;
+        $this->attemptTimeoutMs = $attemptTimeoutMs;
+        $this->initialTimeoutMs = $initialTimeoutMs;
+        $this->clientFactory = $clientFactory;
+    }
+
+    /**
+     * Background discovery: budget = timeoutMs, retries any \Throwable from the RPC
+     * itself until the budget is exhausted. Used by checkDiscovery / handleGrpcStatus
+     * from the request path.
+     *
+     * Note: client-construction errors (e.g., misconfigured iam such as a missing
+     * service file or key) propagate immediately and are NOT retried — they happen
+     * outside the per-attempt try/catch by design.
+     *
+     * @return array
+     * @throws \Throwable
+     */
+    public function listEndpoints(): array
+    {
+        return $this->runRetryLoop($this->timeoutMs, true);
+    }
+
+    /**
+     * Startup discovery: budget = initialTimeoutMs, fail-fast on non-retryable errors.
+     * Used only from the Ydb constructor.
+     *
+     * Note: client-construction errors (e.g., misconfigured iam such as a missing
+     * service file or key) propagate immediately and are NOT retried — they happen
+     * outside the per-attempt try/catch by design.
+     *
+     * @return array
+     * @throws \Throwable
+     */
+    public function initialListEndpoints(): array
+    {
+        return $this->runRetryLoop($this->initialTimeoutMs, false);
+    }
+
+    /**
+     * @param int  $budgetMs        Total time budget for the loop (ms).
+     * @param bool $retryAllErrors  true → retry any \Throwable; false → rethrow
+     *                              non-RetryableException immediately.
+     * @return array
+     * @throws \Throwable
+     */
+    private function runRetryLoop(int $budgetMs, bool $retryAllErrors): array
+    {
+        if ($this->client === null) {
+            $this->initClient();
+        }
+
+        $deadline = microtime(true) + $budgetMs / 1000;
+        $attempt = 0;
+        $last = null;
+        while (microtime(true) < $deadline) {
+            if ($attempt > 0) {
+                $this->backoff($attempt);
+                $this->recreateClient();
+            }
+            try {
+                return $this->doListEndpoints();
+            } catch (\Throwable $e) {
+                $last = $e;
+                if (!$retryAllErrors && !($e instanceof RetryableException)) {
+                    throw $e;
+                }
+                $this->logger()->warning('internal discovery attempt ' . ($attempt + 1) . ' failed: ' . $e->getMessage());
+            }
+            $attempt++;
+        }
+        throw $last !== null ? $last : new \Exception('internal discovery failed');
+    }
+
+    /**
+     * Pass-through of Ydb::grpcOpts() plus 'force_new' when requested.
+     */
+    public function buildClientOpts(bool $forceNew): array
+    {
+        $opts = $this->ydb->grpcOpts();
+        if ($forceNew) {
+            $opts['force_new'] = true;
+        }
+        return $opts;
+    }
+
+    /**
+     * One-shot client construction called lazily on the first listEndpoints() call. No
+     * force_new — gRPC may reuse a cached channel for the bootstrap endpoint if one
+     * happens to exist.
+     */
+    protected function initClient(): void
+    {
+        $this->client = $this->makeClient(false);
+    }
+
+    /**
+     * Called from the retry loop after an error. Closes the previous client and builds
+     * a new one with `force_new` so gRPC c-core does a fresh DNS resolution rather than
+     * reusing the cached persistent channel.
+     */
+    protected function recreateClient(): void
+    {
+        if (isset($this->client) && $this->client !== null) {
+            $this->client->close();
+        }
+        $this->client = $this->makeClient(true);
+    }
+
+    private function makeClient(bool $forceNew)
+    {
+        $opts = $this->buildClientOpts($forceNew);
+        if ($this->clientFactory !== null) {
+            $factory = $this->clientFactory;
+            return $factory($this->bootstrapEndpoint, $opts);
+        }
+        return new ServiceClient($this->bootstrapEndpoint, $opts);
+    }
+
+    /**
+     * @return array
+     * @throws \Throwable
+     */
+    protected function doListEndpoints(): array
+    {
+        // Fresh meta per call: Ydb::meta() includes 'x-ydb-auth-ticket' for non-anonymous
+        // auth via Iam::token() (cached/refreshed by Iam itself).
+        $meta = $this->ydb->meta();
+
+        $request = new ListEndpointsRequest(['database' => $this->ydb->database()]);
+
+        $call = $this->client->ListEndpoints($request, $meta, ['timeout' => $this->attemptTimeoutMs * 1000]);
+        list($response, $status) = $call->wait();
+
+        if (isset($status->code) && $status->code !== 0) {
+            $class = isset(self::$grpcExceptions[$status->code]) ? self::$grpcExceptions[$status->code] : \Exception::class;
+            $name = isset(self::$grpcNames[$status->code]) ? self::$grpcNames[$status->code] : (string)$status->code;
+            $details = isset($status->details) ? $status->details : '';
+            throw new $class('Discovery ListEndpoints (GRPC_' . $name . '): ' . $details);
+        }
+
+        $result = $this->processResponse('Discovery', 'ListEndpoints', $response, '\\Ydb\\Discovery\\ListEndpointsResult');
+        return $this->parseResult($result, 'endpoints', []);
+    }
+
+    /**
+     * @param int $attempt 1-based retry index.
+     */
+    protected function backoff(int $attempt): void
+    {
+        $shift = $attempt - 1;
+        if ($shift > self::BACKOFF_CEILING) {
+            $shift = self::BACKOFF_CEILING;
+        }
+        if ($shift < 0) {
+            $shift = 0;
+        }
+        $delayMs = self::BACKOFF_SLOT_MS * (1 << $shift);
+        usleep($delayMs * 1000);
+    }
+}

--- a/src/Internal/Discovery.php
+++ b/src/Internal/Discovery.php
@@ -20,8 +20,8 @@ class Discovery
     use ParseResultTrait;
     use LoggerTrait;
 
-    const DEFAULT_TIMEOUT_MS         = 5000;
-    const DEFAULT_ATTEMPT_TIMEOUT_MS = 1000;
+    const DEFAULT_TIMEOUT_MS         = 1000;
+    const DEFAULT_ATTEMPT_TIMEOUT_MS = 300;
     const DEFAULT_INITIAL_TIMEOUT_MS = 5000;
 
     const BACKOFF_SLOT_MS = 20;

--- a/src/Ydb.php
+++ b/src/Ydb.php
@@ -23,6 +23,13 @@ class Ydb
     const VERSION = MAJOR.".".MINOR.".".PATCH;
 
     /**
+     * Default gRPC load-balancing policy applied to every channel built via grpcOpts().
+     * Distributes RPCs across all resolved A-records of the target DNS name. Users can
+     * override per-channel via `grpc.opts.grpc.lb_policy_name` in their Ydb config.
+     */
+    const DEFAULT_LB_POLICY_NAME = 'round_robin';
+
+    /**
      * @var string
      */
     protected $endpoint;
@@ -104,7 +111,10 @@ class Ydb
      */
     protected $discoveryInterval = 60;
 
-    protected $triedDiscovery = false;
+    /**
+     * @var \YdbPlatform\Ydb\Internal\Discovery
+     */
+    protected $internalDiscovery;
 
     /**
      * @param array $config
@@ -139,6 +149,15 @@ class Ydb
             }
         }
 
+        $this->internalDiscovery = new Internal\Discovery(
+            $this,
+            isset($config['endpoint']) ? $config['endpoint'] : null,
+            isset($config['discoveryTimeoutMs'])        ? (int)$config['discoveryTimeoutMs']        : Internal\Discovery::DEFAULT_TIMEOUT_MS,
+            isset($config['discoveryAttemptTimeoutMs']) ? (int)$config['discoveryAttemptTimeoutMs'] : Internal\Discovery::DEFAULT_ATTEMPT_TIMEOUT_MS,
+            isset($config['discoveryInitialTimeoutMs']) ? (int)$config['discoveryInitialTimeoutMs'] : Internal\Discovery::DEFAULT_INITIAL_TIMEOUT_MS,
+            $this->logger
+        );
+
         if (!empty($config['discovery']))
         {
             $this->discover = true;
@@ -146,9 +165,7 @@ class Ydb
                 $this->discoveryInterval = $config['discoveryInterval'];
             }
 
-            $this->retry(function (){
-                $this->discover();
-            }, true);
+            $this->applyDiscoveryResult($this->internalDiscovery->initialListEndpoints());
         }
 
         $this->logger()->info('YDB: Initialized');
@@ -189,6 +206,9 @@ class Ydb
     {
         $grpcOpts = (array) ($this->grpc_config['opts'] ?? []);
         $grpcOpts['credentials'] = $this->iam()->getCredentials();
+        if (!isset($grpcOpts['grpc.lb_policy_name'])) {
+            $grpcOpts['grpc.lb_policy_name'] = self::DEFAULT_LB_POLICY_NAME;
+        }
 
         return $grpcOpts;
     }
@@ -204,31 +224,36 @@ class Ydb
     }
 
     /**
-     * Discover available endpoints to connect to.
+     * Background discovery (discoveryTimeoutMs budget, retries any error). Used from
+     * checkDiscovery / handleGrpcStatus on the request path. Startup discovery runs
+     * from the constructor via Internal\Discovery::initialListEndpoints().
      *
      * @return void
      * @throws Exception
      */
     public function discover()
     {
-        if ($this->triedDiscovery)
+        $this->applyDiscoveryResult($this->internalDiscovery->listEndpoints());
+    }
+
+    /**
+     * Apply a ListEndpoints result to the cluster and the current endpoint. Shared
+     * between the startup path (constructor) and the background path (discover()).
+     *
+     * @param array $endpoints
+     * @return void
+     */
+    protected function applyDiscoveryResult(array $endpoints)
+    {
+        if (empty($endpoints)) {
             return;
-
-        $this->triedDiscovery = true;
-
-        try {
-            $endpoints = $this->discovery()->listEndpoints();
-            if (!empty($endpoints)) {
-                $this->cluster()->sync((array)$endpoints);
-                $clusterEndpoints = array_map(function ($e) {
-                    return $e["address"] . ":" . $e["port"];
-                }, (array)$endpoints);
-                if (!array_search($this->endpoint, $clusterEndpoints)) {
-                    $this->endpoint = $clusterEndpoints[array_rand($clusterEndpoints)];
-                }
-            }
-        } finally {
-            $this->triedDiscovery = false;
+        }
+        $this->cluster()->sync($endpoints);
+        $clusterEndpoints = array_map(function ($e) {
+            return $e["address"] . ":" . $e["port"];
+        }, $endpoints);
+        if (!in_array($this->endpoint, $clusterEndpoints, true)) {
+            $this->endpoint = $clusterEndpoints[array_rand($clusterEndpoints)];
         }
     }
 

--- a/src/Ydb.php
+++ b/src/Ydb.php
@@ -229,7 +229,7 @@ class Ydb
      * from the constructor via Internal\Discovery::initialListEndpoints().
      *
      * @return void
-     * @throws Exception
+     * @throws \Throwable
      */
     public function discover()
     {

--- a/src/Ydb.php
+++ b/src/Ydb.php
@@ -123,8 +123,8 @@ class Ydb
      */
     public function __construct($config = [], LoggerInterface $logger = null)
     {
-        $this->endpoint = $config['endpoint'];
-        $this->database = $config['database'];
+        $this->endpoint = $config['endpoint'] ?? null;
+        $this->database = $config['database'] ?? null;
         $this->iam_config = $config['iam_config'] ?? [];
         $this->grpc_config = (array) ($config['grpc'] ?? []);
         $this->grpcTimeout = $config['grpc']['timeout'] ?? null;
@@ -151,7 +151,7 @@ class Ydb
 
         $this->internalDiscovery = new Internal\Discovery(
             $this,
-            $config['endpoint'],
+            $this->endpoint,
             isset($config['discoveryTimeoutMs'])        ? (int)$config['discoveryTimeoutMs']        : Internal\Discovery::DEFAULT_TIMEOUT_MS,
             isset($config['discoveryAttemptTimeoutMs']) ? (int)$config['discoveryAttemptTimeoutMs'] : Internal\Discovery::DEFAULT_ATTEMPT_TIMEOUT_MS,
             isset($config['discoveryInitialTimeoutMs']) ? (int)$config['discoveryInitialTimeoutMs'] : Internal\Discovery::DEFAULT_INITIAL_TIMEOUT_MS,

--- a/src/Ydb.php
+++ b/src/Ydb.php
@@ -123,8 +123,8 @@ class Ydb
      */
     public function __construct($config = [], LoggerInterface $logger = null)
     {
-        $this->endpoint = $config['endpoint'] ?? null;
-        $this->database = $config['database'] ?? null;
+        $this->endpoint = $config['endpoint'];
+        $this->database = $config['database'];
         $this->iam_config = $config['iam_config'] ?? [];
         $this->grpc_config = (array) ($config['grpc'] ?? []);
         $this->grpcTimeout = $config['grpc']['timeout'] ?? null;
@@ -151,7 +151,7 @@ class Ydb
 
         $this->internalDiscovery = new Internal\Discovery(
             $this,
-            isset($config['endpoint']) ? $config['endpoint'] : null,
+            $config['endpoint'],
             isset($config['discoveryTimeoutMs'])        ? (int)$config['discoveryTimeoutMs']        : Internal\Discovery::DEFAULT_TIMEOUT_MS,
             isset($config['discoveryAttemptTimeoutMs']) ? (int)$config['discoveryAttemptTimeoutMs'] : Internal\Discovery::DEFAULT_ATTEMPT_TIMEOUT_MS,
             isset($config['discoveryInitialTimeoutMs']) ? (int)$config['discoveryInitialTimeoutMs'] : Internal\Discovery::DEFAULT_INITIAL_TIMEOUT_MS,

--- a/tests/Internal/DiscoveryTest.php
+++ b/tests/Internal/DiscoveryTest.php
@@ -272,7 +272,7 @@ class DiscoveryTest extends TestCase
     // recreateClient must be called exactly k times.
     // ------------------------------------------------------------------
 
-    public function testSucceedsOnThirdAttemptAndRecreatesOnce(): void
+    public function testSucceedsOnFourthAttemptAndRecreatesThreeTimes(): void
     {
         $ydb = $this->makeYdb();
 

--- a/tests/Internal/DiscoveryTest.php
+++ b/tests/Internal/DiscoveryTest.php
@@ -1,0 +1,412 @@
+<?php
+
+namespace YdbPlatform\Ydb\Test\Internal;
+
+use PHPUnit\Framework\TestCase;
+use YdbPlatform\Ydb\Exceptions\Grpc\InvalidArgumentException;
+use YdbPlatform\Ydb\Exceptions\Grpc\UnavailableException;
+use YdbPlatform\Ydb\Iam;
+use YdbPlatform\Ydb\Internal\Discovery;
+use YdbPlatform\Ydb\Ydb;
+
+class DiscoveryTest extends TestCase
+{
+    private const BOOTSTRAP_ENDPOINT = 'bootstrap-endpoint:2135';
+
+    /**
+     * A DIFFERENT value returned by $ydb->endpoint() to prove createClient ignores
+     * the mutated Ydb endpoint and always targets the bootstrap one.
+     */
+    private const MUTATED_ENDPOINT = 'node-after-discovery:2136';
+
+    /**
+     * @return Ydb&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function makeYdb()
+    {
+        $iam = $this->getMockBuilder(Iam::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['token'])
+            ->getMock();
+        $iam->method('token')->willReturn('fake-token');
+
+        $ydb = $this->getMockBuilder(Ydb::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['grpcOpts', 'meta', 'iam', 'database', 'endpoint'])
+            ->getMock();
+        $ydb->method('grpcOpts')->willReturn([]);
+        $ydb->method('meta')->willReturn(['x-ydb-database' => ['/local']]);
+        $ydb->method('database')->willReturn('/local');
+        $ydb->method('endpoint')->willReturn(self::MUTATED_ENDPOINT);
+        $ydb->method('iam')->willReturn($iam);
+
+        return $ydb;
+    }
+
+    /**
+     * No-op client factory: returns a fake client with close() and ListEndpoints() so
+     * the constructor's initClient() call never builds a real gRPC client.
+     */
+    private function noopClientFactory(): callable
+    {
+        return function ($endpoint, $opts) {
+            return new class {
+                public function close()
+                {
+                }
+
+                public function ListEndpoints($r, $m, $o)
+                {
+                    return null;
+                }
+            };
+        };
+    }
+
+    // ------------------------------------------------------------------
+    // buildClientOpts: pass-through + force_new flag.
+    // ------------------------------------------------------------------
+
+    public function testBuildClientOptsWithoutForceNewIsPassThrough(): void
+    {
+        $ydb = $this->makeYdb();
+        $disc = new Discovery($ydb, self::BOOTSTRAP_ENDPOINT, 300, 100, PHP_INT_MAX, null, $this->noopClientFactory());
+
+        $opts = $disc->buildClientOpts(false);
+
+        $this->assertIsArray($opts);
+        $this->assertArrayNotHasKey('force_new', $opts);
+        // round_robin is now Ydb::grpcOpts()'s responsibility; Discovery doesn't add it.
+        $this->assertArrayNotHasKey('grpc.lb_policy_name', $opts);
+    }
+
+    public function testBuildClientOptsPreservesGrpcOptsContent(): void
+    {
+        $iam = $this->getMockBuilder(Iam::class)->disableOriginalConstructor()->onlyMethods(['token'])->getMock();
+        $iam->method('token')->willReturn('fake-token');
+
+        $sentinelCreds = new \stdClass();
+        $ydb = $this->getMockBuilder(Ydb::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['grpcOpts', 'meta', 'iam', 'database', 'endpoint'])
+            ->getMock();
+        $ydb->method('grpcOpts')->willReturn([
+            'credentials'         => $sentinelCreds,
+            'grpc.lb_policy_name' => 'round_robin',
+            'custom.key'          => 'custom-value',
+        ]);
+        $ydb->method('meta')->willReturn(['x-ydb-database' => ['/local']]);
+        $ydb->method('database')->willReturn('/local');
+        $ydb->method('endpoint')->willReturn(self::MUTATED_ENDPOINT);
+        $ydb->method('iam')->willReturn($iam);
+
+        $disc = new Discovery($ydb, self::BOOTSTRAP_ENDPOINT, 300, 100, PHP_INT_MAX, null, $this->noopClientFactory());
+
+        $optsNoForce = $disc->buildClientOpts(false);
+        $this->assertSame($sentinelCreds, $optsNoForce['credentials']);
+        $this->assertSame('round_robin', $optsNoForce['grpc.lb_policy_name']);
+        $this->assertSame('custom-value', $optsNoForce['custom.key']);
+        $this->assertArrayNotHasKey('force_new', $optsNoForce);
+
+        $optsForce = $disc->buildClientOpts(true);
+        $this->assertSame($sentinelCreds, $optsForce['credentials']);
+        $this->assertSame('round_robin', $optsForce['grpc.lb_policy_name']);
+        $this->assertSame('custom-value', $optsForce['custom.key']);
+        $this->assertTrue($optsForce['force_new']);
+    }
+
+    public function testBuildClientOptsWithForceNewAddsFlag(): void
+    {
+        $ydb = $this->makeYdb();
+        $disc = new Discovery($ydb, self::BOOTSTRAP_ENDPOINT, 300, 100, PHP_INT_MAX, null, $this->noopClientFactory());
+
+        $opts = $disc->buildClientOpts(true);
+
+        $this->assertIsArray($opts);
+        $this->assertTrue($opts['force_new']);
+    }
+
+    // ------------------------------------------------------------------
+    // initClient (lazy): NOT called in ctor; invoked on first listEndpoints (or here,
+    // via reflection). Targets bootstrap endpoint, no force_new.
+    // ------------------------------------------------------------------
+
+    public function testCtorIsCheapAndDoesNotBuildClient(): void
+    {
+        $ydb = $this->makeYdb();
+
+        $calls = 0;
+        $factory = function ($endpoint, $opts) use (&$calls) {
+            $calls++;
+            return new class {
+                public function close() {}
+                public function ListEndpoints($r, $m, $o) { return null; }
+            };
+        };
+
+        new Discovery($ydb, self::BOOTSTRAP_ENDPOINT, 300, 100, PHP_INT_MAX, null, $factory);
+
+        $this->assertSame(0, $calls, 'ctor must NOT build the client — initClient is lazy');
+    }
+
+    public function testInitClientBuildsAgainstBootstrapWithoutForceNew(): void
+    {
+        $ydb = $this->makeYdb();
+
+        $calls = [];
+        $factory = function ($endpoint, $opts) use (&$calls) {
+            $client = new class {
+                public $closed = false;
+                public function close() { $this->closed = true; }
+                public function ListEndpoints($r, $m, $o) { return null; }
+            };
+            $calls[] = ['endpoint' => $endpoint, 'opts' => $opts, 'client' => $client];
+            return $client;
+        };
+
+        $disc = new Discovery($ydb, self::BOOTSTRAP_ENDPOINT, 300, 100, PHP_INT_MAX, null, $factory);
+
+        $initClient = new \ReflectionMethod(Discovery::class, 'initClient');
+        $initClient->setAccessible(true);
+        $initClient->invoke($disc);
+
+        $this->assertCount(1, $calls);
+        $this->assertSame(self::BOOTSTRAP_ENDPOINT, $calls[0]['endpoint']);
+        $this->assertArrayNotHasKey('force_new', $calls[0]['opts'], 'initClient must NOT set force_new');
+    }
+
+    // ------------------------------------------------------------------
+    // recreateClient: targets bootstrap, sets force_new, closes prev client.
+    // ------------------------------------------------------------------
+
+    public function testRecreateClientTargetsBootstrapWithForceNewAndClosesPrevious(): void
+    {
+        $ydb = $this->makeYdb();
+
+        $calls = [];
+        $factory = function ($endpoint, $opts) use (&$calls) {
+            $client = new class {
+                public $closed = false;
+                public function close() { $this->closed = true; }
+                public function ListEndpoints($r, $m, $o) { return null; }
+            };
+            $calls[] = ['endpoint' => $endpoint, 'opts' => $opts, 'client' => $client];
+            return $client;
+        };
+
+        $disc = new Discovery($ydb, self::BOOTSTRAP_ENDPOINT, 300, 100, PHP_INT_MAX, null, $factory);
+
+        // initClient is lazy; trigger it manually so we have a "previous" client to close.
+        $initClient = new \ReflectionMethod(Discovery::class, 'initClient');
+        $initClient->setAccessible(true);
+        $initClient->invoke($disc);
+        $firstClient = $calls[0]['client'];
+
+        $recreate = new \ReflectionMethod(Discovery::class, 'recreateClient');
+        $recreate->setAccessible(true);
+        $recreate->invoke($disc);
+
+        $this->assertCount(2, $calls);
+        $this->assertSame(self::BOOTSTRAP_ENDPOINT, $calls[1]['endpoint'], 'recreateClient must keep targeting the bootstrap endpoint');
+        $this->assertTrue($calls[1]['opts']['force_new'] ?? false, 'recreateClient must request force_new');
+        $this->assertTrue($firstClient->closed, 'recreateClient must close the previously-built client');
+    }
+
+    // ------------------------------------------------------------------
+    // listEndpoints (background): bounded by discoveryTimeoutMs, retries any
+    // \Throwable, throws last on exhaustion.
+    // ------------------------------------------------------------------
+
+    public function testBackgroundRetriesUntilBudgetExhaustedThenThrows(): void
+    {
+        $ydb = $this->makeYdb();
+
+        $recreates = 0;
+        $disc = $this->getMockBuilder(Discovery::class)
+            ->setConstructorArgs([$ydb, self::BOOTSTRAP_ENDPOINT, 30, 5, PHP_INT_MAX, null, $this->noopClientFactory()])
+            ->onlyMethods(['doListEndpoints', 'recreateClient'])
+            ->getMock();
+
+        $disc->method('doListEndpoints')->willThrowException(new \RuntimeException('always fails'));
+        $disc->method('recreateClient')->willReturnCallback(function () use (&$recreates) {
+            $recreates++;
+        });
+
+        try {
+            $disc->listEndpoints();
+            $this->fail('listEndpoints() should throw once the time budget is exhausted');
+        } catch (\Throwable $e) {
+            $this->assertSame('always fails', $e->getMessage());
+        }
+
+        $this->assertGreaterThanOrEqual(1, $recreates, 'background must retry at least once');
+    }
+
+    public function testBackgroundRetriesOnPlainRuntimeException(): void
+    {
+        // Distinguishes Discovery's background loop from the generic Retry, which only
+        // retries RetryableException. Here a plain \RuntimeException must still retry.
+        $ydb = $this->makeYdb();
+
+        $recreates = 0;
+        $disc = $this->getMockBuilder(Discovery::class)
+            ->setConstructorArgs([$ydb, self::BOOTSTRAP_ENDPOINT, 30, 5, PHP_INT_MAX, null, $this->noopClientFactory()])
+            ->onlyMethods(['doListEndpoints', 'recreateClient'])
+            ->getMock();
+
+        $disc->method('doListEndpoints')->willThrowException(new \RuntimeException('non-retryable but background retries anyway'));
+        $disc->method('recreateClient')->willReturnCallback(function () use (&$recreates) {
+            $recreates++;
+        });
+
+        $this->expectException(\RuntimeException::class);
+        try {
+            $disc->listEndpoints();
+        } finally {
+            $this->assertGreaterThanOrEqual(1, $recreates);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Success on the k-th attempt: k failures then a returned array;
+    // recreateClient must be called exactly k times.
+    // ------------------------------------------------------------------
+
+    public function testSucceedsOnThirdAttemptAndRecreatesOnce(): void
+    {
+        $ydb = $this->makeYdb();
+
+        $recreates = 0;
+        $disc = $this->getMockBuilder(Discovery::class)
+            ->setConstructorArgs([$ydb, self::BOOTSTRAP_ENDPOINT, 1000, 5, PHP_INT_MAX, null, $this->noopClientFactory()])
+            ->onlyMethods(['doListEndpoints', 'recreateClient'])
+            ->getMock();
+
+        $disc->method('doListEndpoints')->will($this->onConsecutiveCalls(
+            $this->throwException(new \RuntimeException('fail 1')),
+            $this->throwException(new \RuntimeException('fail 2')),
+            $this->throwException(new \RuntimeException('fail 3')),
+            $this->returnValue(['ok'])
+        ));
+        $disc->method('recreateClient')->willReturnCallback(function () use (&$recreates) {
+            $recreates++;
+        });
+
+        $result = $disc->listEndpoints();
+
+        $this->assertSame(['ok'], $result);
+        $this->assertSame(3, $recreates, 'recreateClient must be called exactly once per retry');
+    }
+
+    // ------------------------------------------------------------------
+    // initialListEndpoints: fail-fast vs retryable.
+    // ------------------------------------------------------------------
+
+    public function testInitialModeFailsFastOnNonRetryableRuntimeException(): void
+    {
+        $ydb = $this->makeYdb();
+
+        $recreates = 0;
+        $doCalls = 0;
+        $disc = $this->getMockBuilder(Discovery::class)
+            ->setConstructorArgs([$ydb, self::BOOTSTRAP_ENDPOINT, 1000, 5, 1000, null, $this->noopClientFactory()])
+            ->onlyMethods(['doListEndpoints', 'recreateClient'])
+            ->getMock();
+
+        $disc->method('doListEndpoints')->willReturnCallback(function () use (&$doCalls) {
+            $doCalls++;
+            throw new \RuntimeException('non-retryable');
+        });
+        $disc->method('recreateClient')->willReturnCallback(function () use (&$recreates) {
+            $recreates++;
+        });
+
+        try {
+            $disc->initialListEndpoints();
+            $this->fail('initial mode must rethrow a non-retryable exception immediately');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('non-retryable', $e->getMessage());
+        }
+
+        $this->assertSame(1, $doCalls, 'initial mode must NOT retry on a non-retryable exception');
+        $this->assertSame(0, $recreates, 'initial mode must NOT recreate the client on a non-retryable exception');
+    }
+
+    public function testInitialModeFailsFastOnNonRetryableGrpcException(): void
+    {
+        $ydb = $this->makeYdb();
+
+        $recreates = 0;
+        $doCalls = 0;
+        $disc = $this->getMockBuilder(Discovery::class)
+            ->setConstructorArgs([$ydb, self::BOOTSTRAP_ENDPOINT, 1000, 5, 1000, null, $this->noopClientFactory()])
+            ->onlyMethods(['doListEndpoints', 'recreateClient'])
+            ->getMock();
+
+        $disc->method('doListEndpoints')->willReturnCallback(function () use (&$doCalls) {
+            $doCalls++;
+            throw new InvalidArgumentException('bad argument');
+        });
+        $disc->method('recreateClient')->willReturnCallback(function () use (&$recreates) {
+            $recreates++;
+        });
+
+        $this->expectException(InvalidArgumentException::class);
+        try {
+            $disc->initialListEndpoints();
+        } finally {
+            $this->assertSame(1, $doCalls);
+            $this->assertSame(0, $recreates);
+        }
+    }
+
+    public function testInitialModeRetriesOnRetryableExceptionWithinBudget(): void
+    {
+        $ydb = $this->makeYdb();
+
+        $recreates = 0;
+        $disc = $this->getMockBuilder(Discovery::class)
+            // small initialTimeoutMs so the loop terminates
+            ->setConstructorArgs([$ydb, self::BOOTSTRAP_ENDPOINT, 1000, 5, 30, null, $this->noopClientFactory()])
+            ->onlyMethods(['doListEndpoints', 'recreateClient'])
+            ->getMock();
+
+        $disc->method('doListEndpoints')->willThrowException(new UnavailableException('unavailable'));
+        $disc->method('recreateClient')->willReturnCallback(function () use (&$recreates) {
+            $recreates++;
+        });
+
+        try {
+            $disc->initialListEndpoints();
+            $this->fail('initial mode should eventually throw once its budget is exhausted');
+        } catch (UnavailableException $e) {
+            $this->assertSame('unavailable', $e->getMessage());
+        }
+
+        $this->assertGreaterThanOrEqual(1, $recreates, 'initial mode must retry/recreate on a retryable exception');
+    }
+
+    public function testInitialModeSucceedsOnSecondAttemptWhenRetryable(): void
+    {
+        $ydb = $this->makeYdb();
+
+        $recreates = 0;
+        $disc = $this->getMockBuilder(Discovery::class)
+            ->setConstructorArgs([$ydb, self::BOOTSTRAP_ENDPOINT, 1000, 5, 1000, null, $this->noopClientFactory()])
+            ->onlyMethods(['doListEndpoints', 'recreateClient'])
+            ->getMock();
+
+        $disc->method('doListEndpoints')->will($this->onConsecutiveCalls(
+            $this->throwException(new UnavailableException('unavailable')),
+            $this->returnValue(['ok'])
+        ));
+        $disc->method('recreateClient')->willReturnCallback(function () use (&$recreates) {
+            $recreates++;
+        });
+
+        $result = $disc->initialListEndpoints();
+
+        $this->assertSame(['ok'], $result);
+        $this->assertSame(1, $recreates, 'one retryable failure -> exactly one recreate');
+    }
+}


### PR DESCRIPTION
- New Internal\Discovery that always targets the original bootstrap endpoint
  and recreates the gRPC channel with force_new on retries, so c-core
  re-resolves DNS and recovers from bootstrap IP changes.
- New config keys: discoveryTimeoutMs (5000), discoveryAttemptTimeoutMs (1000),
  discoveryInitialTimeoutMs (PHP_INT_MAX).
- Default grpc.lb_policy_name = round_robin in Ydb::grpcOpts() (user can
  override via grpc.opts.grpc.lb_policy_name).
- Fixed array_search cluster-endpoint check in Ydb::discover() (returning key
  0 was treated as "not found"); replaced with strict in_array.
- Unit tests in tests/Internal/DiscoveryTest.php.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
