### PR TITLE
Collect and upload test coverage to Codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           extensions: grpc
           php-version: ${{ matrix.php-versions }}
+          coverage: xdebug
 
       - run: composer validate --strict
         name: Validate composer.json and composer.lock
@@ -67,8 +68,18 @@ jobs:
         run: docker exec $(docker ps --latest --quiet) /ydb -e grpc://localhost:2136 -d /local scripting yql -s "CREATE USER testuser PASSWORD 'testpassword'"
 
       - name: Run tests
-        run: ./vendor/bin/phpunit \
-          --coverage-text \
-          --whitelist src \
-          --testdox \
-          tests
+        run: |
+          ./vendor/bin/phpunit \
+            --coverage-text \
+            --coverage-clover=coverage.xml \
+            --whitelist src \
+            --testdox \
+            tests
+
+      - name: Upload coverage to Codecov
+        if: matrix.php-versions == '8.2' && matrix.ydb-versions == 'trunk'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 tmp/
 vendor/
 composer.lock
+coverage.xml
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# YDB PHP SDK
+
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-php-sdk/badge.svg?precision=2)](https://app.codecov.io/gh/ydb-platform/ydb-php-sdk)
+
 YDB PHP SDK provides access to [YDB](https://ydb.tech/) from PHP code.
 
 YDB is a open-source distributed fault-tolerant DBMS with high availability and scalability, strict consistency and ACID. An SQL dialect – YQL – is used for queries.

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,8 +8,8 @@ coverage:
         informational: true
 
 comment:
-  layout: "reach, diff, flags, files"
-  require_changes: true
+  layout: "reach, diff, flags, components, files"
+  require_changes: false
 
 ignore:
   - "protos"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,28 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: true
+
+ignore:
+  - "protos"
+  - "ydb-api-protos"
+  - "examples"
+  - "slo-workload"
+  - "tests"
+  - "php_plugin"
+  - "vendor"
+
+component_management:
+  individual_components:
+    - component_id: native-sdk
+      name: Native SDK
+      paths:
+        - "src/**"


### PR DESCRIPTION
Enable code coverage collection in the tests workflow and upload it to Codecov.

- Generate Clover report and upload from `PHP 8.2 + ydb trunk`
- Add `codecov.yml` with the shared `native-sdk` component
- Add Codecov badge to README