### PR TITLE
CI: Fix CI 

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Changelog updated
         uses: Zomzog/changelog-checker@v1.2.0

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -1,8 +1,9 @@
+# SLO tests are opt-in: they need external infrastructure (k8s cluster, docker
+# registry) configured via repository secrets. Run them manually or by adding
+# the `SLO` label to a pull request, like the other YDB SDK repositories do.
 on:
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
+    types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
 
 name: SLO
@@ -12,7 +13,9 @@ jobs:
     concurrency:
       group: slo-${{ github.ref }}
       cancel-in-progress: true
-    if: (!contains(github.event.pull_request.labels.*.name, 'no slo'))
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'SLO')
 
     runs-on: ubuntu-latest
     name: SLO test

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -13,9 +13,13 @@ jobs:
     concurrency:
       group: slo-${{ github.ref }}
       cancel-in-progress: true
+    # On `labeled` events run only when the `SLO` label itself was just added:
+    # otherwise any unrelated label change on a PR that already carries `SLO`
+    # would start a fresh run and cancel the in-progress one via `cancel-in-progress`.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'SLO')
+      (github.event.action == 'labeled' && github.event.label.name == 'SLO') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'SLO'))
 
     runs-on: ubuntu-latest
     name: SLO test

--- a/.github/workflows/sumplelinter.yml
+++ b/.github/workflows/sumplelinter.yml
@@ -15,7 +15,6 @@ permissions:
 jobs:
   linter:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
     strategy:
       matrix:
         php-versions: [ '7.2' ]

--- a/.github/workflows/sumplelinter.yml
+++ b/.github/workflows/sumplelinter.yml
@@ -15,18 +15,14 @@ permissions:
 jobs:
   linter:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         php-versions: [ '7.2' ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout
-
-      - uses: eWaterCycle/setup-grpc@v5
-        name: Setup gRPC
-        with:
-          grpc-version: 1.51.1
 
       - uses: shivammathur/setup-php@v2
         name: Setup PHP
@@ -38,7 +34,7 @@ jobs:
       - run: composer validate --strict
         name: Validate composer.json and composer.lock
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Cache Composer packages
         id: composer-cache
 
@@ -50,6 +46,6 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
 
-      - name: Run tests
+      - name: Run linter
         run: ./vendor/bin/phplint \
           ./ --exclude=vendor

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
           YDB_USE_IN_MEMORY_PDISKS: true
         options: '-h localhost'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,20 +27,18 @@ jobs:
           YDB_USE_IN_MEMORY_PDISKS: true
         options: '-h localhost'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         php-versions: [ '7.2', '7.4', '8.0', '8.2' ]
         ydb-versions: ['stable-22-5', 'trunk', '23.3', '23.2', '23.1']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout
 
-      - uses: eWaterCycle/setup-grpc@v5
-        name: Setup gRPC
-        with:
-          grpc-version: 1.51.1
-
+      # The grpc PHP extension installed by setup-php is self-contained (it bundles
+      # grpc core), so no separate gRPC build from source is needed.
       - uses: shivammathur/setup-php@v2
         name: Setup PHP
         id: php
@@ -52,7 +50,7 @@ jobs:
       - run: composer validate --strict
         name: Validate composer.json and composer.lock
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Cache Composer packages
         id: composer-cache
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* fixed flaky `RefreshTokenTest`: token refresh is now forced explicitly instead of relying on wall-clock timing
+* CI: dropped the unnecessary gRPC-from-source build step (tests job takes ~1 minute instead of ~10), updated GitHub Actions versions, SLO workflow is now opt-in (`SLO` label or manual run)
+
 ## 1.16.3
 * improve log
 

--- a/tests/RefreshTokenTest.php
+++ b/tests/RefreshTokenTest.php
@@ -5,6 +5,7 @@ namespace YdbPlatform\Ydb\Test;
 use PHPUnit\Framework\TestCase;
 use YdbPlatform\Ydb\Auth\Auth;
 use YdbPlatform\Ydb\Auth\TokenInfo;
+use YdbPlatform\Ydb\Iam;
 use YdbPlatform\Ydb\Ydb;
 
 class FakeCredentials extends Auth {
@@ -28,7 +29,8 @@ class FakeCredentials extends Auth {
         if ($this->counter==2){
             throw new \Exception("Some error");
         }
-        return new TokenInfo(time()+$this->tokenLiveTime,time()+$this->tokenLiveTime);
+        // Token value is unique per call, so a refreshed token is distinguishable from the previous one.
+        return new TokenInfo("token-" . $this->counter, time()+$this->tokenLiveTime);
     }
 
     public function getName(): string
@@ -43,13 +45,32 @@ class MetaGetter extends \YdbPlatform\Ydb\Session{
     }
 }
 
+class IamRefreshForcer extends Iam {
+    /**
+     * Move the refresh deadline of the current token into the past, so the next
+     * request triggers a token refresh without waiting for wall-clock time.
+     */
+    public static function forceRefresh(Iam $iam)
+    {
+        $iam->refresh_at = time() - 1;
+    }
+}
+
 class RefreshTokenTest extends TestCase
 {
     public function testRefreshToken(){
 
         $counter = 0;
 
-        $TOKEN_LIVE_TIME = 10;
+        // Long enough that the token never becomes due for refresh on its own
+        // during the test, so the test does not depend on runner speed.
+        $TOKEN_LIVE_TIME = 3600;
+
+        // Isolate the on-disk token cache from other tests and previous runs:
+        // the cache key is derived from the config, so a token left by an earlier
+        // run of this very test would otherwise be reused and skip the first fetch.
+        $tempDir = sys_get_temp_dir() . '/ydb-refresh-token-test-' . bin2hex(random_bytes(4));
+        mkdir($tempDir, 0700, true);
 
         $config = [
 
@@ -65,6 +86,7 @@ class RefreshTokenTest extends TestCase
             // IAM config
             'iam_config'  => [
                 'insecure' => true,
+                'temp_dir' => $tempDir,
             ],
             'credentials' => new FakeCredentials($counter, $TOKEN_LIVE_TIME)
         ];
@@ -87,8 +109,9 @@ class RefreshTokenTest extends TestCase
             $token,
             MetaGetter::getMeta($session)["x-ydb-auth-ticket"][0]
         );
+
         // Check that sdk used old token when failed refreshing
-        usleep($ydb->iam()->config('credentials')->getRefreshTokenRatio()*$TOKEN_LIVE_TIME*1000*1000); // waiting 10% from token live time
+        IamRefreshForcer::forceRefresh($ydb->iam());
         $session->query('select 1 as res');
         self::assertEquals(
             2,
@@ -99,7 +122,7 @@ class RefreshTokenTest extends TestCase
             MetaGetter::getMeta($session)["x-ydb-auth-ticket"][0]
         );
 
-        // Check that token refreshed
+        // Check that token refreshed on the next attempt
         $session->query('select 1 as res');
         self::assertEquals(
             3,


### PR DESCRIPTION
## Why

CI has been unreliable for a while:

- **`RefreshTokenTest` is flaky.** It slept for 10% of a 10-second token lifetime and asserted on wall-clock behaviour. The refresh deadline is computed in whole seconds, so whenever session creation and the first query straddled a second boundary the test failed (\`Failed asserting that 2 matches expected 1\`). With 20 matrix jobs per run this hit regularly.
- **Every test job spent ~8.5 of ~9.5 minutes in \`eWaterCycle/setup-grpc\`**, building gRPC 1.51.1 from source. The grpc PHP extension installed by \`shivammathur/setup-php\` bundles its own grpc core, so that step is unnecessary. Tests themselves take ~7 seconds.
- **The SLO workflow has failed on every push and PR since June 2026** (\`Incorrect docker repo, username or password\` at docker login). The credentials for the old \`slo-tests\` infrastructure are dead. Other YDB SDKs run SLO only on demand (label / manual dispatch).
- Old action versions (\`checkout@v2/v3\`, \`cache@v3\`) are on the Node 20 deprecation path.

## What

- \`RefreshTokenTest\`: force the refresh deadline into the past explicitly (same protected-access pattern the test already uses for \`meta\`), use an hour-long token so nothing expires by itself, and isolate the on-disk token cache so a token left by a previous run is not reused.
- \`tests.yml\`, \`sumplelinter.yml\`: remove \`setup-grpc\`, bump \`checkout\`/\`cache\`, add job timeouts.
- \`slo.yml\`: run only on \`workflow_dispatch\` or when a PR carries the \`SLO\` label. Migrating to \`ydb-platform/ydb-slo-action\` (as Go/Python SDKs did) is a separate task.
- \`changelog.yml\`: bump \`checkout\`.

## Not fixed here (needs repository settings)

All PRs from forks currently sit in \`action_required\`: the repository's fork-PR approval policy is \`first_time_contributors\`, and the external contributor has no merged PR yet, so every one of their PRs needs a manual "Approve and run". See PR discussion.