### PR TITLE
CI: replace stale cr.yandex/yc/yandex-docker-local-ydb image with ydbplatform/local-ydb

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,22 +16,20 @@ jobs:
   tests:
     services:
       ydb:
-        image: cr.yandex/yc/yandex-docker-local-ydb:${{ matrix.ydb-versions }}
+        image: ydbplatform/local-ydb:${{ matrix.ydb-versions }}
         ports:
           - 2135:2135
           - 2136:2136
           - 8765:8765
         volumes:
           - /tmp/ydb_certs:/ydb_certs
-        env:
-          YDB_USE_IN_MEMORY_PDISKS: true
         options: '-h localhost'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         php-versions: [ '7.2', '7.4', '8.0', '8.2' ]
-        ydb-versions: ['stable-22-5', 'trunk', '23.3', '23.2', '23.1']
+        ydb-versions: ['24.4', '25.4', 'latest', 'edge', 'trunk']
     steps:
       - uses: actions/checkout@v4
         name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* CI: replaced the stale `cr.yandex/yc/yandex-docker-local-ydb` test image (numbered tags stop at 23.3, no `latest`) with the actively-maintained `ydbplatform/local-ydb` (used by the Go/Python/Java/.NET/Rust/Node.js SDKs); refreshed the version matrix to `['24.4', '25.4', 'latest', 'edge', 'trunk']`
 
 ## 1.16.3
 * improve log


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The CI service image is pulled from `cr.yandex/yc/yandex-docker-local-ydb`. That registry's numbered release tags stop at `23.3` (2023) and it has no `latest` tag, so the matrix (`['stable-22-5', 'trunk', '23.3', '23.2', '23.1']`) only exercises 2022-2023 snapshots plus one bleeding-edge `trunk` build - no released 24.x/25.x/26.x version is covered.

Issue Number: #293

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Service image switched to `ydbplatform/local-ydb`, the image already used by the Go/Python/Java/.NET/Rust/Node.js SDKs' own CI, which is actively updated (`latest` is currently a real `26.1.1.22` build).
- Matrix refreshed to `['24.4', '25.4', 'latest', 'edge', 'trunk']`.
- Dropped `YDB_USE_IN_MEMORY_PDISKS`, which this image doesn't read.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Verified live that binary paths (`/ydbd`, `/ydb`), default database (`/local`), default ports (`2135`/`2136`/`8765`) and default TLS cert path (`/ydb_certs`) are unchanged between the two images, so no other service config needed to change.